### PR TITLE
Fix build on macOS

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -22,7 +22,6 @@ function(add_atsplugin name)
   target_link_libraries(${name} PRIVATE traffic_server)
   set_target_properties(${name} PROPERTIES PREFIX "")
   set_target_properties(${name} PROPERTIES SUFFIX ".so")
-  set_target_properties(${name} PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib")
   install(TARGETS ${name} DESTINATION libexec/trafficserver)
 endfunction()
 

--- a/plugins/experimental/slice/CMakeLists.txt
+++ b/plugins/experimental/slice/CMakeLists.txt
@@ -32,7 +32,7 @@ add_atsplugin(slice
     util.cc
 )
 
-target_link_libraries(access_control PRIVATE PCRE::PCRE)
+target_link_libraries(slice PRIVATE ts::tscore)
 
 if(BUILD_TESTING)
     add_subdirectory(unit-tests)

--- a/plugins/s3_auth/CMakeLists.txt
+++ b/plugins/s3_auth/CMakeLists.txt
@@ -19,4 +19,6 @@ project(s3_auth)
 
 add_atsplugin(s3_auth s3_auth.cc aws_auth_v4.cc)
 
+target_link_libraries(s3_auth PRIVATE ts::tscore)
+
 add_subdirectory(unit_tests)

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -120,7 +120,7 @@ if(TS_USE_POSIX_CAP)
     target_link_libraries(tscore PUBLIC cap::cap)
 endif()
 
-add_dependencies(tscore ParseRules tscpputil)
+add_dependencies(tscore ParseRules)
 target_include_directories(tscore PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}
         ${YAML_INCLUDE_DIRS}

--- a/src/tscpp/api/CMakeLists.txt
+++ b/src/tscpp/api/CMakeLists.txt
@@ -49,6 +49,6 @@ target_link_libraries(tscppapi
     )
 install(TARGETS tscppapi)
 
-if (APPLE)
-    set_target_properties(tscppapi PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-endif(APPLE)
+if(APPLE)
+  target_link_options(tscppapi PRIVATE -undefined dynamic_lookup)
+endif()

--- a/src/tscpp/api/CMakeLists.txt
+++ b/src/tscpp/api/CMakeLists.txt
@@ -46,7 +46,7 @@ target_link_libraries(tscppapi
     PUBLIC
     libswoc
     yaml-cpp::yaml-cpp
-    )
+)
 install(TARGETS tscppapi)
 
 if(APPLE)

--- a/src/tscpp/api/CMakeLists.txt
+++ b/src/tscpp/api/CMakeLists.txt
@@ -45,5 +45,10 @@ add_library(ts::tscppapi ALIAS tscppapi)
 target_link_libraries(tscppapi
     PUBLIC
     libswoc
-    yaml-cpp::yaml-cpp)
+    yaml-cpp::yaml-cpp
+    )
 install(TARGETS tscppapi)
+
+if (APPLE)
+    set_target_properties(tscppapi PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+endif(APPLE)

--- a/src/tscpp/util/CMakeLists.txt
+++ b/src/tscpp/util/CMakeLists.txt
@@ -26,7 +26,8 @@ target_link_libraries(tscpputil
 	PUBLIC
 		libswoc
 		yaml-cpp::yaml-cpp
-                ts::tscore)
+                ts::tscore
+)
 install(TARGETS tscpputil)
 
 add_executable(test_tscpputil

--- a/src/tscpp/util/CMakeLists.txt
+++ b/src/tscpp/util/CMakeLists.txt
@@ -25,7 +25,8 @@ add_library(ts::tscpputil ALIAS tscpputil)
 target_link_libraries(tscpputil
 	PUBLIC
 		libswoc
-		yaml-cpp::yaml-cpp)
+		yaml-cpp::yaml-cpp
+                ts::tscore)
 install(TARGETS tscpputil)
 
 add_executable(test_tscpputil


### PR DESCRIPTION
- Use -undefined dynamic_lookup to ignore unresolved dependencies which are located inside traffic_server
- Add some missing dependencies
- Break a cyclic dependency between tscppapi and tscore