### PR TITLE
Add pointer to StripeSM

### DIFF
--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -428,7 +428,7 @@ check_bucket_not_contains(Dir *b, Dir *e, Dir *seg)
 }
 
 void
-freelist_clean(int s, Stripe *stripe)
+freelist_clean(int s, StripeSM *stripe)
 {
   dir_clean_segment(s, stripe);
   if (stripe->header->freelist[s]) {
@@ -452,7 +452,7 @@ freelist_clean(int s, Stripe *stripe)
 }
 
 inline Dir *
-freelist_pop(int s, Stripe *stripe)
+freelist_pop(int s, StripeSM *stripe)
 {
   Dir *seg = stripe->dir_segment(s);
   Dir *e   = dir_from_offset(stripe->header->freelist[s], seg);

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -366,12 +366,12 @@ dir_clean_bucket(Dir *b, int s, Stripe *stripe)
 #endif
     if (!dir_valid(stripe, e) || !dir_offset(e)) {
       if (dbg_ctl_dir_clean.on()) {
-        Dbg(dbg_ctl_dir_clean, "cleaning Stripe:%s: %p tag %X boffset %" PRId64 " b %p p %p bucket len %d", stripe->hash_text.get(),
-            e, dir_tag(e), dir_offset(e), b, p, dir_bucket_length(b, s, stripe));
+        Dbg(dbg_ctl_dir_clean, "cleaning Stripe:%s: %p tag %X boffset %" PRId64 " b %p p %p bucket len %d",
+            stripe->stripe_sm->hash_text.get(), e, dir_tag(e), dir_offset(e), b, p, dir_bucket_length(b, s, stripe));
       }
       if (dir_offset(e)) {
         Metrics::Gauge::decrement(cache_rsb.direntries_used);
-        Metrics::Gauge::decrement(stripe->cache_vol->vol_rsb.direntries_used);
+        Metrics::Gauge::decrement(stripe->stripe_sm->cache_vol->vol_rsb.direntries_used);
       }
       e = dir_delete_entry(e, p, s, stripe);
       continue;
@@ -407,7 +407,7 @@ dir_clear_range(off_t start, off_t end, Stripe *stripe)
     Dir *e = dir_index(stripe, i);
     if (dir_offset(e) >= static_cast<int64_t>(start) && dir_offset(e) < static_cast<int64_t>(end)) {
       Metrics::Gauge::decrement(cache_rsb.direntries_used);
-      Metrics::Gauge::decrement(stripe->cache_vol->vol_rsb.direntries_used);
+      Metrics::Gauge::decrement(stripe->stripe_sm->cache_vol->vol_rsb.direntries_used);
       dir_set_offset(e, 0); // delete
     }
   }

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -88,7 +88,7 @@ Stripe::dir_check()
 
   ink_zero(frag_demographics);
 
-  printf("Stripe '[%s]'\n", hash_text.get());
+  printf("Stripe '[%s]'\n", this->stripe_sm->hash_text.get());
   printf("  Directory Bytes: %" PRIu64 "\n", total_buckets * SIZEOF_DIR);
   printf("  Segments:  %d\n", segments);
   printf("  Buckets per segment:   %" PRIu64 "\n", buckets);

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -285,12 +285,12 @@ Stripe::_init_data()
 }
 
 bool
-Stripe::flush_aggregate_write_buffer()
+Stripe::flush_aggregate_write_buffer(int fd)
 {
   // set write limit
   this->header->agg_pos = this->header->write_pos + this->_write_buffer.get_buffer_pos();
 
-  if (!this->_write_buffer.flush(this->fd, this->header->write_pos)) {
+  if (!this->_write_buffer.flush(fd, this->header->write_pos)) {
     return false;
   }
   this->header->last_write_pos  = this->header->write_pos;

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -225,7 +225,7 @@ Stripe::dir_check()
 }
 
 void
-Stripe::_clear_init()
+Stripe::_clear_init(std::uint32_t hw_sector_size)
 {
   size_t dir_len = this->dirlen();
   memset(this->raw_dir, 0, dir_len);
@@ -239,7 +239,7 @@ Stripe::_clear_init()
   this->header->cycle                                              = 0;
   this->header->create_time                                        = time(nullptr);
   this->header->dirty                                              = 0;
-  this->sector_size = this->header->sector_size = this->disk->hw_sector_size;
+  this->sector_size = this->header->sector_size = hw_sector_size;
   *this->footer                                 = *this->header;
 }
 

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -150,7 +150,7 @@ public:
 protected:
   AggregateWriteBuffer _write_buffer;
 
-  void _clear_init();
+  void _clear_init(std::uint32_t hw_sector_size);
   void _init_dir();
   void _init_data();
   bool flush_aggregate_write_buffer(int fd);

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -155,7 +155,7 @@ protected:
   void _clear_init();
   void _init_dir();
   void _init_data();
-  bool flush_aggregate_write_buffer();
+  bool flush_aggregate_write_buffer(int fd);
 
 private:
   void _init_data_internal();

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -83,7 +83,6 @@ class Stripe
 public:
   ats_scoped_str hash_text;
   char          *path = nullptr;
-  int            fd{-1};
 
   char                *raw_dir{nullptr};
   Dir                 *dir{};

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -82,7 +82,6 @@ class Stripe
 {
 public:
   ats_scoped_str hash_text;
-  char          *path = nullptr;
 
   char                *raw_dir{nullptr};
   Dir                 *dir{};

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -81,7 +81,7 @@ struct StripteHeaderFooter {
 class Stripe
 {
 public:
-  ats_scoped_str hash_text;
+  StripeSM *stripe_sm{nullptr};
 
   char                *raw_dir{nullptr};
   Dir                 *dir{};
@@ -96,8 +96,6 @@ public:
   off_t                data_blocks{};
 
   uint32_t sector_size{};
-
-  CacheVol *cache_vol{};
 
   int dir_check();
 

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -95,8 +95,7 @@ public:
   off_t                len{};
   off_t                data_blocks{};
 
-  CacheDisk *disk{};
-  uint32_t   sector_size{};
+  uint32_t sector_size{};
 
   CacheVol *cache_vol{};
 

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -141,7 +141,7 @@ int
 StripeSM::clear_dir()
 {
   size_t dir_len = this->dirlen();
-  this->_clear_init();
+  this->_clear_init(this->disk->hw_sector_size);
 
   if (pwrite(this->fd, this->raw_dir, dir_len, this->skip) < 0) {
     Warning("unable to clear cache directory '%s'", this->hash_text.get());
@@ -298,7 +298,7 @@ int
 StripeSM::clear_dir_aio()
 {
   size_t dir_len = this->dirlen();
-  this->_clear_init();
+  this->_clear_init(this->disk->hw_sector_size);
 
   SET_HANDLER(&StripeSM::handle_dir_clear);
 

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -1365,7 +1365,7 @@ StripeSM::shutdown(EThread *shutdown_thread)
   // directories have not been inserted for these writes
   if (!this->_write_buffer.is_empty()) {
     Dbg(dbg_ctl_cache_dir_sync, "Dir %s: flushing agg buffer first", this->hash_text.get());
-    this->flush_aggregate_write_buffer();
+    this->flush_aggregate_write_buffer(this->fd);
   }
 
   // We already asserted that dirlen > 0.

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -78,6 +78,8 @@ public:
 
   Event *trigger = nullptr;
 
+  CacheDisk *disk{};
+
   OpenDir              open_dir;
   RamCache            *ram_cache = nullptr;
   DLL<EvacuationBlock> lookaside[LOOKASIDE_SIZE];

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -65,6 +65,7 @@ class StripeSM : public Continuation, public Stripe
 {
 public:
   CryptoHash hash_id;
+  char      *path = nullptr;
   int        fd{-1};
 
   int hit_evacuate_window{};

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -65,6 +65,7 @@ class StripeSM : public Continuation, public Stripe
 {
 public:
   CryptoHash hash_id;
+  ats_scoped_str hash_text;
   char      *path = nullptr;
   int        fd{-1};
 
@@ -78,6 +79,7 @@ public:
 
   Event *trigger = nullptr;
 
+  CacheVol  *cache_vol{};
   CacheDisk *disk{};
 
   OpenDir              open_dir;
@@ -162,6 +164,7 @@ public:
 
   StripeSM() : Continuation(new_ProxyMutex())
   {
+    stripe_sm      = this;
     open_dir.mutex = mutex;
     SET_HANDLER(&StripeSM::aggWrite);
   }

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -65,6 +65,7 @@ class StripeSM : public Continuation, public Stripe
 {
 public:
   CryptoHash hash_id;
+  int        fd{-1};
 
   int hit_evacuate_window{};
 


### PR DESCRIPTION
Probably, we should move `CacheVol *cache_vol` too. Because `StripeSM` represents a intersection of `CacheVol` and `CacheDisk`. Then, it'll has the same issue of moving `ats_scoped_str hash_text`. A tricky idea is adding a pointer to `StripeSM` to the `Stripe`.